### PR TITLE
Add a reconciler option to override the default prune whitelist for `…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/erain/kubebuilder-declarative-pattern
+module github.com/giuliano-sider/kubebuilder-declarative-pattern
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,6 @@ require (
 	k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655
 	k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90
 	sigs.k8s.io/controller-runtime v0.4.0
-	sigs.k8s.io/kustomize/api v0.2.0
+	sigs.k8s.io/kustomize/api v0.3.2
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/pkg/patterns/declarative/options.go
+++ b/pkg/patterns/declarative/options.go
@@ -44,6 +44,7 @@ type reconcilerParams struct {
 	manifestController    ManifestController
 
 	prune             bool
+	pruneWhitelist    []schema.GroupVersionKind
 	preserveNamespace bool
 	kustomize         bool
 	validate          bool
@@ -117,6 +118,21 @@ func WithManifestController(mc ManifestController) reconcilerOption {
 func WithApplyPrune() reconcilerOption {
 	return func(p reconcilerParams) reconcilerParams {
 		p.prune = true
+		return p
+	}
+}
+
+// WithApplyPruneWhitelist turns on the --prune behavior of kubectl apply, and also
+// takes a list of GroupVersionKind that will each be passed as --prune-whitelist
+// arguments to kubectl apply, overriding the default prune whitelist used by that command.
+// An empty list implies that the default prune whitelist will be used. Check the
+// kubectl code for a specific version to know what that is, as kubectl apply --prune
+// is an alpha feature which is not completely documented.
+// For an example (kubectl v1.20.7), see https://github.com/kubernetes/kubernetes/blob/132a687512d7fb058d0f5890f07d4121b3f0a2e2/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go#L177
+func WithApplyPruneWhitelist(pruneWhitelist []schema.GroupVersionKind) reconcilerOption {
+	return func(p reconcilerParams) reconcilerParams {
+		p.prune = true
+		p.pruneWhitelist = pruneWhitelist
 		return p
 	}
 }


### PR DESCRIPTION
…kubectl apply --prune`.

The default prune whitelist for `kubectl apply --prune` ([in v1.20.7 for the sake of illustration](https://github.com/kubernetes/kubernetes/blob/132a687512d7fb058d0f5890f07d4121b3f0a2e2/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go#L177), but this may very depending on the version since `kubectl apply prune` is an alpha feature) doesn't prune custom resources and many others like Mutating and Validating WebhookConfigurations. On the other hand, it does prune namespaces, which may be undesirable in many situations. An operator often needs better control over the resources which are pruned by kubectl, and this change provides the means to achieve it.